### PR TITLE
Output lcov for vscode-coverage-gutters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ gem 'rubocop', '~> 1.65', require: false
 gem 'rubocop-rake', '~> 0.6', require: false
 gem 'rubocop-rspec', '~> 3.0', require: false
 gem 'simplecov', '~> 0.22', require: false
+gem 'simplecov-lcov', '~> 0.8.0', require: false
 gem 'yard', require: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,18 @@ require 'danger'
 require 'pry'
 require 'rspec'
 require 'simplecov'
+require 'simplecov-lcov'
+SimpleCov::Formatter::LcovFormatter.config do |c|
+  c.report_with_single_file = true
+  c.output_directory = 'coverage'
+  c.lcov_file_name = 'lcov.info'
+end
+
 SimpleCov.start do
   load_profile 'test_frameworks'
   enable_coverage :branch
+  formatter SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::LcovFormatter,
+                                                      SimpleCov::Formatter::HTMLFormatter])
 end
 require 'danger_plugin'
 require 'support/helpers'


### PR DESCRIPTION
https://github.com/ryanluker/vscode-coverage-gutters/tree/v2.12.0/example/ruby#installation
